### PR TITLE
Fix wrongly removing target objects when undoing a relationship

### DIFF
--- a/src/flask_restalchemy/resources/resources.py
+++ b/src/flask_restalchemy/resources/resources.py
@@ -238,13 +238,13 @@ class ToManyRelationResource(BaseModelResource):
         return saved
 
     def delete(self, relation_id, id):
+        session = self._db_session
         requested_obj = self._query_related_obj(relation_id, id)
         if not requested_obj:
             return NOT_FOUND_ERROR, 404
-        session = self._db_session
-        session.delete(requested_obj)
-        was_deleted = len(session.deleted) > 0
-        session.flush()
+        related_obj = session.query(self._related_model).get(relation_id)
+        collection = getattr(related_obj, self._relation_property.key)
+        collection.remove(requested_obj)
         session.commit()
         return '', 204
 

--- a/src/flask_restalchemy/tests/test_api_relations.py
+++ b/src/flask_restalchemy/tests/test_api_relations.py
@@ -89,11 +89,13 @@ def test_put_item(client):
 
 def test_delete_item(client):
     company = Company.query.get(3)
-    assert set([emp.firstname for emp in company.employees]) == {'Jim', 'Sarah'}
+    assert [emp.firstname for emp in company.employees] == ['Sarah', 'Jim']
 
     resp = client.delete('/company/3/employees/9')
     assert resp.status_code == 204
     assert [emp.firstname for emp in company.employees] == ['Sarah']
+    # Make sure that delete just drop the relation, and do not delete the target objects itself
+    assert Employee.query.filter_by(firstname='Jim').first()
 
     assert client.delete('/company/5/employees/999').status_code == 404
 


### PR DESCRIPTION
When posting a DELETE to a relationship, the target object was being
wrongly removed from database, instead of just undo the objects
relation.

Fixed by changing delete method of ToManyResource class.

RFDAP-1941